### PR TITLE
Fix to show the content ui changes in xcode preview window

### DIFF
--- a/TaskList/TaskList/ContentView.swift
+++ b/TaskList/TaskList/ContentView.swift
@@ -82,6 +82,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
-    }
+        let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+        
+        return ContentView().environment(\.managedObjectContext, context)    }
 }


### PR DESCRIPTION
The preview window does not show the ui changes and require to run the application in simulator.  This fix will render the UI in preview to design the ui without running on simulator.

Closes #2 